### PR TITLE
ゲストログイン機能の追加

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -121,6 +121,10 @@ header{
   padding-right: 8%;
 }
 
+#user_name{
+  white-space: nowrap;
+}
+
 //ハンバーガーメニュー
 .menu-content{
   width: auto;

--- a/app/controllers/guest_sessions_controller.rb
+++ b/app/controllers/guest_sessions_controller.rb
@@ -4,6 +4,7 @@ class GuestSessionsController < ApplicationController
       user.password = "hogehoge"
       user.password_confirmation = "hogehoge"
       user.name = "ゲスト"
+      user.id = 100
     end
     log_in(@user)
     flash[:notice] = "ゲストユーザーとしてログインしました"

--- a/app/controllers/guest_sessions_controller.rb
+++ b/app/controllers/guest_sessions_controller.rb
@@ -1,13 +1,13 @@
 class GuestSessionsController < ApplicationController
   def create
-    @user = User.find_or_create_by(email: "guest@example.com") do |user|
-      user.password = "hogehoge"
-      user.password_confirmation = "hogehoge"
-      user.name = "ゲスト"
+    @user = User.find_or_create_by(email: 'guest@example.com') do |user|
+      user.password = 'hogehoge'
+      user.password_confirmation = 'hogehoge'
+      user.name = 'ゲスト'
       user.id = 100
     end
     log_in(@user)
-    flash[:notice] = "ゲストユーザーとしてログインしました"
+    flash[:notice] = 'ゲストユーザーとしてログインしました'
     redirect_to :root
   end
 end

--- a/app/controllers/guest_sessions_controller.rb
+++ b/app/controllers/guest_sessions_controller.rb
@@ -1,0 +1,12 @@
+class GuestSessionsController < ApplicationController
+  def create
+    @user = User.find_or_create_by(email: "guest@example.com") do |user|
+      user.password = "hogehoge"
+      user.password_confirmation = "hogehoge"
+      user.name = "ゲスト"
+    end
+    log_in(@user)
+    flash[:notice] = "ゲストユーザーとしてログインしました"
+    redirect_to :root
+  end
+end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,5 +1,7 @@
 class PostsController < ApplicationController
+  include GuestSessionsHelper
   before_action :logged_in_user
+  before_action :guest_check, only: %i[update destroy]
 
   def index
     gon.map_key = ENV['Google_Map_API']

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,8 @@
 class UsersController < ApplicationController
+  include GuestSessionsHelper
   before_action :logged_in_user, only: %i[account profile edit profile_update update]
   before_action :forbid_login_user, only: %i[new create]
+  before_action :guest_check, only: %i[profile_update update destroy]
 
   def new
     @user = User.new

--- a/app/helpers/guest_sessions_helper.rb
+++ b/app/helpers/guest_sessions_helper.rb
@@ -1,0 +1,2 @@
+module GuestSessionsHelper
+end

--- a/app/helpers/guest_sessions_helper.rb
+++ b/app/helpers/guest_sessions_helper.rb
@@ -1,2 +1,7 @@
 module GuestSessionsHelper
+  def guest_check
+    if @current_user == User.find(100)
+      redirect_to root_path,notice: "ゲストユーザーにはこの機能はありません。"
+    end
+  end
 end

--- a/app/helpers/guest_sessions_helper.rb
+++ b/app/helpers/guest_sessions_helper.rb
@@ -1,7 +1,11 @@
 module GuestSessionsHelper
   def guest_check
-    if @current_user == User.find(100)
-      redirect_to root_path,notice: "ゲストユーザーにはこの機能はありません。"
-    end
+    redirect_to root_path, notice: 'ゲストユーザーにはこの機能はありません' if guest_user?
+  end
+
+  private
+
+  def guest_user?
+    session[:user_id] == 100
   end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -23,7 +23,7 @@
         </div>
         <% if @current_user %>
           <div class="user_info_top">
-            <div class="title"><%= @current_user.name %></div>
+            <div class="title" id="user_name"><%= @current_user.name %></div>
             <div class="hamburger-menu">
               <input type="checkbox" id="menu-btn-check" />
               <label for="menu-btn-check" class="menu-btn">
@@ -46,6 +46,7 @@
           </div>
           <% else %>
             <div class="button" id=user_button_form">
+              <%= link_to "ゲストログイン（お試し）", :guest_login, class:"button", id:"login_button", method: :post %>
               <%= link_to "ログイン", :login, class:"button", id:"login_button" %>
               <%= link_to "登録", :new_user, class:"button", id:"register_button" %>
             </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,7 @@ Rails.application.routes.draw do
   root  :to => 'top#top'
   get    'maps/index'
   get    'posts/index'
+  post   'guest_login',                     to: 'guest_sessions#create'
   post   '/search',                         to: 'search#search'
   get    '/login',                          to: 'sessions#new'
   post   '/login',                          to: 'sessions#create'

--- a/spec/support/login_helper.rb
+++ b/spec/support/login_helper.rb
@@ -8,6 +8,6 @@ module LoginHelpers
 
   def guest_login
     visit root_path
-    page.first("#login_button").click
+    page.first('#login_button').click
   end
 end

--- a/spec/support/login_helper.rb
+++ b/spec/support/login_helper.rb
@@ -5,4 +5,9 @@ module LoginHelpers
     fill_in 'session[password]', with: user.password
     click_button 'ログイン'
   end
+
+  def guest_login
+    visit root_path
+    page.first("#login_button").click
+  end
 end

--- a/spec/system/guest_sessions_spec.rb
+++ b/spec/system/guest_sessions_spec.rb
@@ -1,12 +1,11 @@
 require 'rails_helper'
 
-RSpec.describe "GuestSessions", type: :system do
-
+RSpec.describe 'GuestSessions', type: :system do
   scenario 'ゲストログインする' do
     visit root_path
-    page.first("#login_button").click
+    page.first('#login_button').click
     expect(current_path).to eq root_path
-    expect(page).to have_content "ゲストユーザーとしてログインしました"
+    expect(page).to have_content 'ゲストユーザーとしてログインしました'
   end
 
   scenario 'ゲストログアウトする' do
@@ -15,5 +14,55 @@ RSpec.describe "GuestSessions", type: :system do
     click_on 'ログアウト'
     expect(current_path).to eq login_path
     expect(page).to have_content 'ログアウトしました'
+  end
+
+  describe 'ゲストユーザー機能制限' do
+    let!(:post1) { create(:post, title: '投稿1') }
+    before do
+      guest_login
+    end
+
+    scenario 'アカウント削除ができないこと' do
+      visit users_account_path
+      click_on '削除'
+      expect(current_path).to eq root_path
+      expect(page).to have_content 'ゲストユーザーにはこの機能はありません'
+    end
+
+    scenario 'アカウント編集ができないこと' do
+      visit users_account_path
+      click_on '編集'
+      click_on '更新'
+      expect(current_path).to eq root_path
+      expect(page).to have_content 'ゲストユーザーにはこの機能はありません'
+    end
+
+    scenario 'プロフィール編集ができないこと' do
+      visit users_profile_path
+      click_on '更新'
+      expect(current_path).to eq root_path
+      expect(page).to have_content 'ゲストユーザーにはこの機能はありません'
+    end
+
+    scenario '投稿編集ができないこと' do
+      visit "/posts/100/edit?post_id=#{post1.id}"
+      click_on '更新'
+      expect(current_path).to eq root_path
+      expect(page).to have_content 'ゲストユーザーにはこの機能はありません'
+    end
+
+    scenario '投稿削除ができないこと' do
+      visit new_post_path
+      fill_in 'post[title]', with: 'クジラ発見'
+      attach_file 'post[image]', 'spec/fixtures/post_test_image.jpg'
+      select '東京都', from: 'post_place_prefecture'
+      fill_in 'post[place_detail]', with: '八丈島底土港'
+      fill_in 'post[description]', with: 'ザトウクジラを港で見ました'
+      click_on '送信'
+      visit '/posts/100/index'
+      click_link '削除'
+      expect(current_path).to eq root_path
+      expect(page).to have_content 'ゲストユーザーにはこの機能はありません'
+    end
   end
 end

--- a/spec/system/guest_sessions_spec.rb
+++ b/spec/system/guest_sessions_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe "GuestSessions", type: :system do
+
+  scenario 'ゲストログインする' do
+    visit root_path
+    page.first("#login_button").click
+    expect(current_path).to eq root_path
+    expect(page).to have_content "ゲストユーザーとしてログインしました"
+  end
+
+  scenario 'ゲストログアウトする' do
+    guest_login
+    expect(current_path).to eq root_path
+    click_on 'ログアウト'
+    expect(current_path).to eq login_path
+    expect(page).to have_content 'ログアウトしました'
+  end
+end

--- a/test/controllers/guest_sessions_controller_test.rb
+++ b/test/controllers/guest_sessions_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class GuestSessionsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/controllers/guest_sessions_controller_test.rb
+++ b/test/controllers/guest_sessions_controller_test.rb
@@ -1,4 +1,4 @@
-require "test_helper"
+require 'test_helper'
 
 class GuestSessionsControllerTest < ActionDispatch::IntegrationTest
   # test "the truth" do


### PR DESCRIPTION
アカウント作成なしでアプリの概要を見て頂くために、ゲストログイン機能を追加

ゲストユーザーでは以下の機能を制限
・ユーザー（アカウント編集、プロフィール編集、削除）
・投稿（投稿編集、削除）